### PR TITLE
Add Elliott Wave dynamic labeller and enhanced entry signal

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -1,6 +1,6 @@
 # 🧠 agent.md — Gold AI: Elliott-MACD Realistic QA Agent
-**Version:** v1.3.0
-**Last updated:** 2025-05-26
+**Version:** v1.3.1
+**Last updated:** 2025-05-27
 **Maintainer:** AI Studio QA / Dev Agent System  
 
 ## 📌 Agent Role: `elliott_macd_backtest_agent`
@@ -20,6 +20,8 @@ This agent runs **realistic backtests** on XAUUSD M1 historical data using:
 | `load_data()` | Parse and convert Pali/Buddhist date to AD. Handle `timestamp` as datetime index. |
 | `calculate_indicators()` | Calculate MACD line, signal line, histogram, EMA35 |
 | `detect_signal()` | Generate entry signal using Divergence + MACD Cross + EMA Touch |
+| `detect_elliott_wave_phase()` | Dynamic W1-W5/A-B-C labeling using RSI and divergence |
+| `generate_entry_signal_wave_enhanced()` | Entry only during W.2/W.3/W.5/B with EMA filter |
 | `run_backtest()` | Execute realistic backtest on last N rows (e.g., 200,000) |
 | `apply_constraints()` | Apply spread, slippage, and commission before evaluating PnL |
 | `generate_log()` | Export `trade_log.csv` with entry/exit/timestamp/pnl/commission |
@@ -36,7 +38,8 @@ This agent runs **realistic backtests** on XAUUSD M1 historical data using:
 agent = ElliottMACDBacktestAgent()
 df = agent.load_data("XAUUSD_M1.csv")
 df = agent.calculate_indicators(df)
-signal_df = agent.detect_signal(df)
+df = agent.detect_elliott_wave_phase(df)
+signal_df = agent.generate_entry_signal_wave_enhanced(df)
 result_df = agent.run_backtest(signal_df, last_n_rows=200000)
 agent.export_log(result_df, path="realistic_trade_log.csv")
 ```

--- a/changelog.md
+++ b/changelog.md
@@ -38,3 +38,8 @@
 - Wave phase labeling system
 - Elliott-DivMeta Hybrid signal
 - TP1 at 0.8R with break-even stop
+
+## [v1.3.1] — 2025-05-27
+### Added
+- Elliott Wave Dynamic Labeller v2.1 with zigzag + RSI divergence
+- Entry Signal enhanced by wave phase filtering

--- a/tests/test_nicegold.py
+++ b/tests/test_nicegold.py
@@ -52,5 +52,27 @@ class TestIndicators(unittest.TestCase):
         df = nicegold.label_wave_phase(df)
         self.assertIn('Wave_Phase', df.columns)
 
+    @unittest.skipUnless(pandas_available and numpy_available, 'requires pandas and numpy')
+    def test_detect_elliott_wave_phase_column(self):
+        df = pd.DataFrame({
+            'close': [1, 2, 1, 3, 1, 4, 1],
+            'RSI': [40, 60, 40, 60, 40, 60, 40],
+            'divergence': ['bullish', 'bearish', 'bullish', 'bearish', 'bullish', 'bearish', 'bullish']
+        })
+        df = nicegold.detect_elliott_wave_phase(df)
+        self.assertIn('Wave_Phase', df.columns)
+
+    @unittest.skipUnless(pandas_available and numpy_available, 'requires pandas and numpy')
+    def test_generate_entry_signal_wave_enhanced_column(self):
+        df = pd.DataFrame({
+            'close': [1, 2, 3, 4],
+            'RSI': [60, 60, 60, 60],
+            'ema35': [1, 2, 3, 4],
+            'divergence': ['bullish', 'bullish', 'bullish', 'bullish'],
+            'Wave_Phase': ['W.2', 'W.3', 'W.5', 'W.B']
+        })
+        df = nicegold.generate_entry_signal_wave_enhanced(df)
+        self.assertIn('entry_signal', df.columns)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- implement `detect_elliott_wave_phase` for dynamic W1-W5/B labeling
- implement `generate_entry_signal_wave_enhanced`
- update docs and changelog for v1.3.1
- extend unit tests

## Testing
- `pytest -q`