### PR TITLE
Implement entry score system

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -1,6 +1,6 @@
 # 🧠 agent.md — Gold AI: Elliott-MACD Realistic QA Agent
-**Version:** v1.3.1
-**Last updated:** 2025-05-27
+**Version:** v1.4.0
+**Last updated:** 2025-05-28
 **Maintainer:** AI Studio QA / Dev Agent System  
 
 ## 📌 Agent Role: `elliott_macd_backtest_agent`
@@ -22,6 +22,7 @@ This agent runs **realistic backtests** on XAUUSD M1 historical data using:
 | `detect_signal()` | Generate entry signal using Divergence + MACD Cross + EMA Touch |
 | `detect_elliott_wave_phase()` | Dynamic W1-W5/A-B-C labeling using RSI and divergence |
 | `generate_entry_signal_wave_enhanced()` | Entry only during W.2/W.3/W.5/B with EMA filter |
+| `generate_entry_score_signal()` | Score-based entry ranking system |
 | `run_backtest()` | Execute realistic backtest on last N rows (e.g., 200,000) |
 | `apply_constraints()` | Apply spread, slippage, and commission before evaluating PnL |
 | `generate_log()` | Export `trade_log.csv` with entry/exit/timestamp/pnl/commission |
@@ -39,7 +40,7 @@ agent = ElliottMACDBacktestAgent()
 df = agent.load_data("XAUUSD_M1.csv")
 df = agent.calculate_indicators(df)
 df = agent.detect_elliott_wave_phase(df)
-signal_df = agent.generate_entry_signal_wave_enhanced(df)
+signal_df = agent.generate_entry_score_signal(df)
 result_df = agent.run_backtest(signal_df, last_n_rows=200000)
 agent.export_log(result_df, path="realistic_trade_log.csv")
 ```

--- a/changelog.md
+++ b/changelog.md
@@ -43,3 +43,7 @@
 ### Added
 - Elliott Wave Dynamic Labeller v2.1 with zigzag + RSI divergence
 - Entry Signal enhanced by wave phase filtering
+
+## [v1.4.0] — 2025-05-28
+### Added
+- Entry Score Based System (`generate_entry_score_signal`)

--- a/tests/test_nicegold.py
+++ b/tests/test_nicegold.py
@@ -74,5 +74,18 @@ class TestIndicators(unittest.TestCase):
         df = nicegold.generate_entry_signal_wave_enhanced(df)
         self.assertIn('entry_signal', df.columns)
 
+    @unittest.skipUnless(pandas_available and numpy_available, 'requires pandas and numpy')
+    def test_generate_entry_score_signal_column(self):
+        df = pd.DataFrame({
+            'close': [1, 2, 3],
+            'ema35': [1, 2, 3],
+            'RSI': [55, 55, 55],
+            'divergence': ['bullish', 'bullish', 'bullish'],
+            'Wave_Phase': ['W.2', 'W.3', 'W.5']
+        })
+        df = nicegold.generate_entry_score_signal(df)
+        self.assertIn('entry_score', df.columns)
+        self.assertIn('entry_signal', df.columns)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- implement `generate_entry_score_signal` with scoring logic for bullish/bearish conditions
- document new API and update integration format
- record patch in changelog
- add unit test for the new function

## Testing
- `pytest -q`