### PR TITLE
Patch G33: ปรับปรุงกลยุทธ์ Fold #1

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -1,6 +1,6 @@
 # 🧠 agent.md — Gold AI: Elliott-MACD Realistic QA Agent
-**Version:** v1.5.0
-**Last updated:** 2025-05-28
+**Version:** v1.6.0
+**Last updated:** 2025-05-29
 **Maintainer:** AI Studio QA / Dev Agent System  
 
 ## 📌 Agent Role: `elliott_macd_backtest_agent`

--- a/changelog.md
+++ b/changelog.md
@@ -51,3 +51,7 @@
 ## [v1.5.0] — 2025-05-28
 ### Added
 - Unit tests for full coverage (100%)
+
+## [v1.6.0] — 2025-05-29
+### Added
+- Patch G33: Fold #1 parameter optimization, MACD cross divergence entry, spike score for force entry, and reversal scoring

--- a/tests/test_nicegold.py
+++ b/tests/test_nicegold.py
@@ -31,6 +31,7 @@ class TestIndicators(unittest.TestCase):
         df = nicegold.validate_divergence(df)
         df = nicegold.generate_entry_signal(df)
         self.assertIn('entry_signal', df.columns)
+        self.assertIn('spike_score', df.columns)
 
     @unittest.skipUnless(pandas_available and numpy_available, 'requires pandas and numpy')
     def test_trend_confirm_column(self):

--- a/tests/test_nicegold_extra.py
+++ b/tests/test_nicegold_extra.py
@@ -86,5 +86,20 @@ class TestNicegoldExtra(unittest.TestCase):
         }
         self.assertFalse(nicegold.should_force_entry(row, now - timedelta(minutes=500), now))
 
+    @unittest.skipUnless(pandas_available and numpy_available, 'requires pandas and numpy')
+    def test_apply_wave_macd_cross_entry(self):
+        df = pd.DataFrame({
+            'entry_signal': [None]*5,
+            'Wave_Phase': ['W.1', 'W.2', 'W.B', 'W.5', 'W.2'],
+            'divergence': ['bullish', 'bullish', 'bullish', 'bearish', 'bullish'],
+            'macd_cross_up': [False, True, True, False, True],
+            'macd_cross_down': [False, False, False, True, False],
+            'RSI': [50, 50, 50, 50, 50],
+            'close': [1, 1, 1, 1, 1],
+            'ema35': [1, 1, 1, 1, 1]
+        })
+        result = nicegold.apply_wave_macd_cross_entry(df.copy())
+        self.assertEqual(result['entry_signal'].tolist()[2:], ['buy', 'sell', 'buy'])
+
 if __name__ == '__main__':  # pragma: no cover
     unittest.main()


### PR DESCRIPTION
## Summary
- เพิ่มการคำนวณ `spike_score` ในตัวกรองสไปค์
- ปรับค่า `Signal_Score` ให้รวมรูปแบบ `Reversal`
- เพิ่มฟังก์ชัน `apply_wave_macd_cross_entry` สำหรับเข้าซื้อ/ขายเมื่อ MACD cross พร้อม divergence
- ปรับ cooldown ของ `should_force_entry` เหลือ 180 นาที
- ใช้พารามิเตอร์ Fold #1 ใน backtest และเรียกใช้ logic ใหม่
- อัปเดตเอกสารเวอร์ชันเป็น 1.6.0 และเพิ่มบันทึกการเปลี่ยนแปลง
- เพิ่ม unit test สำหรับฟังก์ชันใหม่และตรวจสอบ `spike_score`

## Testing
- `pytest -q`
