### PR TITLE
Improve timestamp parsing for Buddhist CSV

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -1,6 +1,6 @@
 # 🧠 agent.md — Gold AI: Elliott-MACD Realistic QA Agent
-**Version:** v1.7.0
-**Last updated:** 2025-05-30
+**Version:** v1.8.0
+**Last updated:** 2025-05-31
 **Maintainer:** AI Studio QA / Dev Agent System  
 
 ## 📌 Agent Role: `elliott_macd_backtest_agent`

--- a/changelog.md
+++ b/changelog.md
@@ -59,3 +59,7 @@
 ## [v1.7.0] — 2025-05-30
 ### Added
 - Patch G34: Wave phase divergence logic with pd.isna fix, spike_score calculation, and force entry cooldown tweak
+
+## [v1.8.0] — 2025-05-31
+### Added
+- Patch G35: `load_data` now parses Buddhist `Date` and non zero-padded `Timestamp`

--- a/nicegold.py
+++ b/nicegold.py
@@ -1,6 +1,29 @@
 import pandas as pd
 import numpy as np
 
+# === โหลดข้อมูล ===
+def load_data(file_path):
+    """อ่านไฟล์ CSV ที่มีคอลัมน์ Date (พ.ศ.) และ Timestamp แล้วแปลงเป็น datetime"""
+    df = pd.read_csv(file_path)
+    df.columns = [c.lower() for c in df.columns]
+    if 'date' not in df.columns or 'timestamp' not in df.columns:
+        return df
+
+    year = df['date'].astype(str).str.slice(0, 4).astype(int) - 543
+    month = df['date'].astype(str).str.slice(4, 6).astype(int)
+    day = df['date'].astype(str).str.slice(6, 8).astype(int)
+
+    datetime_str = (
+        year.astype(str)
+        + '-' + month.astype(str).str.zfill(2)
+        + '-' + day.astype(str).str.zfill(2)
+        + ' '
+        + df['timestamp'].astype(str)
+    )
+    df['timestamp'] = pd.to_datetime(datetime_str, format='%Y-%m-%d %H:%M:%S')
+    df = df.drop(columns=['date'])
+    return df
+
 # === คำนวณ Indicator ===
 def calculate_macd(df, price_col='close', fast=12, slow=26, signal=9):
     ema_fast = df[price_col].ewm(span=fast, adjust=False).mean()

--- a/tests/test_nicegold_extra.py
+++ b/tests/test_nicegold_extra.py
@@ -7,6 +7,7 @@ numpy_available = importlib.util.find_spec('numpy') is not None
 if pandas_available and numpy_available:
     import pandas as pd
     import numpy as np
+    import io
     import sys, os
     sys.path.append(os.path.dirname(os.path.dirname(__file__)))
     import nicegold
@@ -100,6 +101,16 @@ class TestNicegoldExtra(unittest.TestCase):
         })
         result = nicegold.apply_wave_macd_cross_entry(df.copy())
         self.assertEqual(result['entry_signal'].tolist()[2:], ['buy', 'sell', 'buy'])
+
+    @unittest.skipUnless(pandas_available and numpy_available, 'requires pandas and numpy')
+    def test_load_data_timestamp_parsing(self):
+        csv_data = """Date,Timestamp,Open,High,Low,Close,Volume
+25630501,0:00:00,1,1,1,1,0
+25630501,0:15:00,1,1,1,1,0
+"""
+        df = nicegold.load_data(io.StringIO(csv_data))
+        self.assertEqual(df['timestamp'].iloc[0], pd.Timestamp('2020-05-01 00:00:00'))
+        self.assertEqual(df['timestamp'].iloc[1], pd.Timestamp('2020-05-01 00:15:00'))
 
 if __name__ == '__main__':  # pragma: no cover
     unittest.main()


### PR DESCRIPTION
## Summary
- add `load_data` for Pali calendar CSV data
- test timestamp parsing from CSV
- update agent and changelog docs

## Testing
- `pytest -q`