### PR TITLE
เพิ่มระบบ config และบันทึกผล Backtest

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,10 @@
+risk_per_trade: 0.05
+ml_estimators: 50
+signal_threshold: 0.6
+initial_capital: 100.0
+trade_start_hour: 13
+trade_end_hour: 22
+kill_switch_min: 70
+tp1_mult: 0.8
+tp2_mult: 2.0
+target_threshold: 0.002

--- a/tests/test_modern_scalping.py
+++ b/tests/test_modern_scalping.py
@@ -48,7 +48,16 @@ class TestModernScalping(unittest.TestCase):
         })
         df = nicegold.compute_features(df)
         df = nicegold.train_signal_model(df)
-        trades = nicegold.run_backtest(df)
+        cfg = {
+            'initial_capital': 100.0,
+            'risk_per_trade': 0.05,
+            'tp1_mult': 0.8,
+            'tp2_mult': 2.0,
+            'trade_start_hour': 0,
+            'trade_end_hour': 23,
+            'kill_switch_min': 70,
+        }
+        trades = nicegold.run_backtest(df, cfg)
         self.assertIsInstance(trades, pd.DataFrame)
 
 if __name__ == '__main__':  # pragma: no cover


### PR DESCRIPTION
## Notes
- เพิ่มไฟล์ `config.yaml` สำหรับตั้งค่ากลยุทธ์
- `load_config` และตัวกรองเวลาเทรดใน `run_backtest`
- บันทึก trade log พร้อมคำนวณ drawdown และแสดง Win Rate แบบปลอดภัย
- ปรับ unit test ให้ใช้พารามิเตอร์ใหม่