### PR TITLE
Implement equity curve tracking and flexible signals

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -1,7 +1,7 @@
 # 🧠 agent.md — Gold AI: Elliott-MACD Realistic QA Agent
 
-**Version:** v1.9.5
-**Last updated:** 2025-06-06
+**Version:** v1.9.6
+**Last updated:** 2025-06-07
 
 **Maintainer:** AI Studio QA / Dev Agent System  
 

--- a/changelog.md
+++ b/changelog.md
@@ -92,3 +92,8 @@
 - Combined all unit tests into a single `test_all.py` for easier maintenance
 =======
 
+## [v1.9.6] — 2025-06-07
+### Added
+- Patch G33.4: Equity curve tracking saved to `equity_curve.csv`
+- Patch G33.5: Reduced ML thresholds and added debug logging
+

--- a/config.yaml
+++ b/config.yaml
@@ -1,10 +1,10 @@
 risk_per_trade: 0.05
 ml_estimators: 50
-signal_threshold: 0.6
+signal_threshold: 0.55
 initial_capital: 100.0
 trade_start_hour: 13
 trade_end_hour: 22
 kill_switch_min: 70
 tp1_mult: 0.8
 tp2_mult: 2.0
-target_threshold: 0.002
+target_threshold: 0.0015

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -249,6 +249,29 @@ class TestModernScalping(unittest.TestCase):
         self.assertIsInstance(trades, pd.DataFrame)
 
     @unittest.skipUnless(pandas_available and numpy_available and sklearn_available, 'requires pandas, numpy, sklearn')
+    def test_run_backtest_creates_equity_curve(self):
+        df = pd.DataFrame({
+            'close': np.linspace(1, 2, 80),
+            'high': np.linspace(1, 2, 80) + 0.1,
+            'low': np.linspace(1, 2, 80) - 0.1,
+            'timestamp': pd.date_range('2020-01-01', periods=80, freq='T')
+        })
+        df = nicegold.compute_features(df)
+        df = nicegold.train_signal_model(df)
+        cfg = {
+            'initial_capital': 100.0,
+            'risk_per_trade': 0.05,
+            'tp1_mult': 0.8,
+            'tp2_mult': 2.0,
+            'trade_start_hour': 0,
+            'trade_end_hour': 23,
+            'kill_switch_min': 70,
+        }
+        nicegold.run_backtest(df, cfg)
+        self.assertTrue(os.path.exists('equity_curve.csv'))
+        os.remove('equity_curve.csv')
+
+    @unittest.skipUnless(pandas_available and numpy_available and sklearn_available, 'requires pandas, numpy, sklearn')
     def test_load_config_and_time_filter(self):
         cfg = nicegold.load_config() if hasattr(nicegold, 'load_config') else {
             'trade_start_hour': 2,


### PR DESCRIPTION
## Summary
- tweak ML thresholds and add debug output in `train_signal_model`
- track equity curve in `run_backtest` and export to CSV
- adjust config defaults
- update unit tests for equity curve file
- update agent spec and changelog

## Testing
- `pytest -q`