### PR TITLE
เพิ่มสคริปต์แปลงวันที่ AD เป็น พ.ศ.

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -1,8 +1,8 @@
 # 🧠 agent.md — Gold AI: Elliott-MACD Realistic QA Agent
 
 
-**Version:** v1.9.10
-**Last updated:** 2025-06-11
+**Version:** v1.9.11
+**Last updated:** 2025-06-12
 
 
 **Maintainer:** AI Studio QA / Dev Agent System  
@@ -31,6 +31,7 @@
 | `run_backtest()` | Execute realistic backtest on last N rows (e.g., 200,000) |
 | `apply_constraints()` | Apply spread, slippage, and commission before evaluating PnL |
 | `generate_log()` | Export `trade_log.csv` with entry/exit/timestamp/pnl/commission |
+| `convert_csv_ad_to_be()` | Convert AD `Date` column to Buddhist Era |
 
 ### ⚙️ Environment Assumptions:
 - Input data is from `/content/drive/MyDrive/NICEGOLD/XAUUSD_M1.csv` with Buddhist `Date` + `Timestamp`

--- a/changelog.md
+++ b/changelog.md
@@ -119,3 +119,8 @@
 - Patch G-FixNoTrade-NaNATR: Drop rows with NaN indicators before backtest
 - `run()` now drops NaN ATR/RSI/EMA35 rows before generating signals
 
+## [v1.9.11] — 2025-06-12
+### Added
+- Script `convert_csv_ad_to_be` for converting AD dates to Buddhist Era
+- Additional unit test for the new function
+

--- a/nicegold.py
+++ b/nicegold.py
@@ -74,6 +74,33 @@ def load_data(file_path=None):
     logger.debug("Loaded %d rows", len(df))
     return df
 
+# === แปลง CSV จาก ค.ศ. เป็น พ.ศ. ===
+def convert_csv_ad_to_be(input_csv, output_csv=None):
+    """แปลงคอลัมน์ Date ในไฟล์ CSV จาก ค.ศ. เป็น พ.ศ."""
+    logger.debug("Converting AD dates to BE from %s", input_csv)
+    df = pd.read_csv(input_csv)
+    df.columns = [c.lower() for c in df.columns]
+    if 'date' not in df.columns:
+        logger.debug("Date column missing")
+        if output_csv:
+            df.to_csv(output_csv, index=False)
+        return df
+
+    year = df['date'].astype(str).str.slice(0, 4).astype(int) + 543
+    month = df['date'].astype(str).str.slice(4, 6).astype(int)
+    day = df['date'].astype(str).str.slice(6, 8).astype(int)
+
+    df['date'] = (
+        year.astype(str)
+        + month.astype(str).str.zfill(2)
+        + day.astype(str).str.zfill(2)
+    )
+    logger.debug("Converted %d rows", len(df))
+    if output_csv:
+        df.to_csv(output_csv, index=False)
+        logger.debug("Saved converted CSV to %s", output_csv)
+    return df
+
 # === คำนวณ Indicator ===
 def calculate_macd(df, price_col='close', fast=12, slow=26, signal=9):
     logger.debug("Calculating MACD")

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -378,6 +378,17 @@ class TestNewFunctions(unittest.TestCase):
         self.assertIsInstance(trades, pd.DataFrame)
 
 
+class TestConvertCSV(unittest.TestCase):
+    @unittest.skipUnless(pandas_available and numpy_available, 'requires pandas and numpy')
+    def test_convert_csv_ad_to_be(self):
+        csv_data = """Date,Timestamp,Open
+20240501,0:00:00,1
+20240502,0:15:00,1
+"""
+        df = nicegold.convert_csv_ad_to_be(io.StringIO(csv_data))
+        self.assertEqual(df['date'].tolist(), ['25670501', '25670502'])
+
+
 
 class TestLogging(unittest.TestCase):
     def test_get_logger(self):


### PR DESCRIPTION
## รายละเอียด
- เพิ่มฟังก์ชัน `convert_csv_ad_to_be` ใน `nicegold.py` สำหรับแปลงคอลัมน์วันที่จาก ค.ศ. เป็น พ.ศ. พร้อม debug log
- เพิ่ม unit test ตรวจสอบการแปลงวันที่
- ปรับปรุง `agent.md` และ `changelog.md` เป็นเวอร์ชัน v1.9.11

## การทดสอบ
- รัน `pytest -q` ได้ผ่านทั้งหมด