### PR TITLE
Update entry strategy with RSI, Gain_Z and win streak sizing

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -1,8 +1,8 @@
 # 🧠 agent.md — Gold AI: Elliott-MACD Realistic QA Agent
 
 
-**Version:** v1.9.11
-**Last updated:** 2025-06-12
+**Version:** v1.9.12
+**Last updated:** 2025-06-13
 
 
 **Maintainer:** AI Studio QA / Dev Agent System  

--- a/changelog.md
+++ b/changelog.md
@@ -124,3 +124,10 @@
 - Script `convert_csv_ad_to_be` for converting AD dates to Buddhist Era
 - Additional unit test for the new function
 
+## [v1.9.12] — 2025-06-13
+### Changed
+- Expanded indicator preprocessing with RSI, Gain_Z, and Pattern_Label
+- Updated hybrid entry logic and force entry conditions
+- Added win streak boost for position sizing
+- Unit tests updated for new behavior
+

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -170,6 +170,17 @@ class TestNicegoldExtra(unittest.TestCase):
         self.assertFalse(nicegold.should_force_entry(row, now - timedelta(minutes=500), now))
 
     @unittest.skipUnless(pandas_available and numpy_available, 'requires pandas and numpy')
+    def test_should_force_entry_without_pattern(self):
+        row = {
+            'entry_signal': None,
+            'spike_score': 0.7,
+            'Gain_Z': 0.6,
+        }
+        last_entry = datetime(2020, 1, 1, 0, 0, 0)
+        current_time = last_entry + timedelta(minutes=300)
+        self.assertTrue(nicegold.should_force_entry(row, last_entry, current_time))
+
+    @unittest.skipUnless(pandas_available and numpy_available, 'requires pandas and numpy')
     def test_apply_wave_macd_cross_entry(self):
         df = pd.DataFrame({
             'entry_signal': [None] * 5,


### PR DESCRIPTION
## Summary
- expand indicator preprocessing with RSI and Gain_Z
- refine hybrid entry logic and force entry rules
- add win streak boost variable for dynamic lot sizing
- update docs and changelog
- extend unit tests

## Testing
- `pytest -q`