### PR TITLE
ปรับปรุงระบบสัญญาณ SMC และชุดทดสอบ

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -2,7 +2,7 @@
 
 
 
-**Version:** v1.9.24
+**Version:** v1.9.27
 
 
 
@@ -122,4 +122,8 @@ agent.export_log(result_df, path="realistic_trade_log.csv")
 ### 📝 Patch v1.9.26
 - เพิ่มชุดฟังก์ชัน SMC Multi-Timeframe (OB/FVG/Liquidity Grab)
 - เพิ่มฟังก์ชัน `detect_order_block`, `detect_fvg`, `detect_liquidity_grab`, `is_smc_entry`
+
+### 📝 Patch v1.9.27
+- ปรับปรุง `generate_smart_signal` ให้ใช้ข้อมูล M15 และยืนยันโซน SMC
+- ปรับ `run_backtest_cli` ให้ใช้สัญญาณ SMC พร้อมเหตุผลเข้าออเดอร์ใหม่
 

--- a/changelog.md
+++ b/changelog.md
@@ -210,3 +210,9 @@
 - เพิ่มชุดฟังก์ชัน SMC Multi-Timeframe และตัวช่วยตรวจจับโซน
 - ฟังก์ชันใหม่ `detect_order_block`, `detect_fvg`, `detect_liquidity_grab`, `is_smc_entry`
 
+## [v1.9.27] — 2025-06-27
+### Changed
+- ปรับ `run_backtest_cli` ใช้สัญญาณแบบ SMC Multi-Timeframe
+- ปรับ `generate_smart_signal` ให้โหลดข้อมูล M15 และแมพโซน OB/FVG/Liquidity Grab
+- เพิ่มเหตุผลการเข้าออเดอร์แบบ SMC ในบันทึกเทรด
+


### PR DESCRIPTION
## Notes
- เปลี่ยนการคำนวณสัญญาณให้ใช้ SMC หลายกรอบเวลา
- ปรับ `run_backtest_cli` และเหตุผลการเข้าออเดอร์ให้รองรับโซน SMC
- เพิ่ม patch note v1.9.27 ในเอกสาร
- แก้ชุดทดสอบให้สอดคล้องกับฟังก์ชันใหม่

## Testing
- `pytest -q`