### PR TITLE
Add wave labeling and scoring pipeline

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -34,3 +34,7 @@
 - เพิ่มฟังก์ชัน `smart_entry_signal_goldai2025_style` สำหรับสร้างสัญญาณแบบ GoldAI2025
 - ปรับ `run_backtest` และ `run_backtest_multi_tf` ให้เรียกใช้ฟังก์ชันใหม่
 
+## v3.10 QA Patch
+- เพิ่มฟังก์ชัน label_elliott_wave, detect_divergence, label_pattern
+- เพิ่ม calc_gain_zscore, calc_signal_score และ meta_classifier_filter
+- ปรับ pipeline ใน run_backtest และ run_backtest_multi_tf ให้เรียกใช้โมดูลใหม่

--- a/changelog.md
+++ b/changelog.md
@@ -306,3 +306,8 @@
 - ฟังก์ชัน `smart_entry_signal_goldai2025_style` สำหรับสร้างสัญญาณเทรดแบบ GoldAI2025
 - ปรับ `run_backtest` และ `run_backtest_multi_tf` ให้ใช้ตรรกะสัญญาณใหม่นี้
 
+## [v1.9.46] — 2025-07-16
+### Added
+- ระบบ Label Elliott Wave, Detect Divergence และ Pattern Tagging
+- ฟังก์ชัน Gain_Zscore, Signal Score และ Meta Classifier
+- ปรับ pipeline ใน run_backtest ให้เรียกใช้โมดูลใหม่


### PR DESCRIPTION
## Summary
- add functions for Elliott wave labeling, divergence, pattern tagging
- compute gain Z-score, signal score, and meta classifier filter
- update backtest pipelines to call new functions
- document new patch in agent and changelog
- test new helpers

## Testing
- `pytest -q`