### PR TITLE
Update entry strategy and risk parameters

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -73,3 +73,9 @@
 - ระยะ SL ขั้นต่ำ 5 จุด และกรอง ATR < spread x2.5
 - จำกัด lot ไม่เกิน 0.05 ต่อไม้
 - เพิ่ม debug log รายงาน ATR และค่าใช้จ่ายทุกไม้
+
+## v3.18 QA Patch
+- ปรับค่าคอมมิชชันเป็น 0.10 และ slippage 0.2
+- ปรับ risk management (tp1_mult=2.0, tp2_mult=4.0, sl_mult=1.2, min_sl_dist=4)
+- เพิ่มฟังก์ชัน `multi_session_trend_scalping` และใช้ใน pipeline `run_backtest`
+- บันทึกจำนวนสัญญาณเข้าออเดอร์แบบละเอียด

--- a/changelog.md
+++ b/changelog.md
@@ -354,3 +354,11 @@
 - ขยาย TP multiplier และ SL multiplier ตามค่าพารามิเตอร์ใหม่
 - กรอง ATR ต่ำกว่า `spread x2.5` ไม่เข้าเทรด และจำกัด lot ≤ 0.05
 - เพิ่ม unit test ตรวจสอบ lot cap ใหม่
+
+## [v1.9.54] — 2025-07-24
+### Changed
+- ปรับค่าคอมมิชชันเป็น 0.10 และ slippage 0.2
+- ปรับ TP1/TP2 และ SL multiplier ให้สมจริง
+- เพิ่มกลยุทธ์ `multi_session_trend_scalping` และปรับ pipeline backtest
+- กรอง ATR ต่ำกว่า `spread x2.0` ไม่เข้าเทรด
+- เพิ่ม unit test และ log ครบถ้วน

--- a/tests/test_enterprise.py
+++ b/tests/test_enterprise.py
@@ -449,6 +449,23 @@ class TestSpikeNewsGuard(unittest.TestCase):
         results = enterprise.run_walkforward_backtest(df, n_folds=2)
         self.assertEqual(len(results), 2)
 
+    def test_multi_session_trend_scalping_basic(self):
+        df = pd.DataFrame(
+            {
+                "timestamp": pd.date_range("2020-01-01 08:00", periods=60, freq="min"),
+                "ema_fast": [2] * 60,
+                "ema_slow": [1] * 60,
+                "rsi": [60] * 60,
+                "atr": np.linspace(0.5, 1.5, 60),
+            }
+        )
+        res = enterprise.multi_session_trend_scalping(df)
+        self.assertTrue((res["entry_signal"] == "buy").any())
+
+    def test_constants_values(self):
+        self.assertEqual(enterprise.COMMISSION_PER_LOT, 0.10)
+        self.assertEqual(enterprise.SLIPPAGE, 0.2)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- implement `multi_session_trend_scalping` entry logic
- adjust realistic trading costs and risk parameters
- filter low ATR trades
- simplify `run_backtest` pipeline for the new entry method
- update unit tests and documentation

## Testing
- `pytest -q`