### PR TITLE
Add multi-TF EMA+ADX strategy with adaptive lot and QA

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -79,3 +79,9 @@
 - ปรับ risk management (tp1_mult=2.0, tp2_mult=4.0, sl_mult=1.2, min_sl_dist=4)
 - เพิ่มฟังก์ชัน `multi_session_trend_scalping` และใช้ใน pipeline `run_backtest`
 - บันทึกจำนวนสัญญาณเข้าออเดอร์แบบละเอียด
+
+## v3.19 QA Patch
+- เพิ่มฟังก์ชัน `smart_entry_signal_multi_tf_ema_adx` สำหรับกลยุทธ์ Multi-TF + EMA + ADX
+- เพิ่ม `calc_adaptive_lot` และ `on_price_update_patch`
+- อัปเดต `OMSManager` ให้ตรวจสอบความถี่การเปิดออเดอร์และปิด Recovery เมื่อทุนกลับคืน
+- เพิ่ม `qa_validate_backtest` ตรวจสอบกำไร ≥ $15, ออเดอร์ ≥ 15 และ DD ไม่เกิน kill switch

--- a/changelog.md
+++ b/changelog.md
@@ -362,3 +362,12 @@
 - เพิ่มกลยุทธ์ `multi_session_trend_scalping` และปรับ pipeline backtest
 - กรอง ATR ต่ำกว่า `spread x2.0` ไม่เข้าเทรด
 - เพิ่ม unit test และ log ครบถ้วน
+
+## [v1.9.55] — 2025-07-25
+### Added
+- กลยุทธ์ `smart_entry_signal_multi_tf_ema_adx` ใช้ EMA Fast/Slow, ADX, RSI และ Wick filter
+- ฟังก์ชัน `calc_adaptive_lot` ปรับขนาด lot ตาม ADX/Recovery/WinStreak
+- `on_price_update_patch` สำหรับ Partial TP และ Trailing SL
+- ปรับปรุง `OMSManager` ตรวจสอบความถี่การเทรดและปิด Recovery เมื่อทุนกลับคืน
+- เพิ่ม `qa_validate_backtest` สำหรับ QA Validation หลังแบ็กเทสต์
+- เพิ่ม unit tests ครอบคลุมฟีเจอร์ใหม่


### PR DESCRIPTION
## Summary
- implement `smart_entry_signal_multi_tf_ema_adx` for multi-timeframe trend entries
- add adaptive lot sizing and enhanced OMS manager
- introduce QA validation after backtests
- provide helper `on_price_update_patch`
- update docs with new patch notes
- extend tests for new functions

## Testing
- `pytest -q`