### PR TITLE
Implement Always On entry signal

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -96,3 +96,7 @@
 - ปรับ force close เร็วหาก ATR หรือ `gain_z` ต่ำหลังถือ 25 แท่ง
 - Recovery mode ลดความเสี่ยงและข้ามไม้เมื่อ momentum ไม่ดี
 - เพิ่ม `analyze_tradelog` สรุปสถิติ win/loss streak และ drawdown
+
+## v3.22 QA Patch
+- เพิ่มฟังก์ชัน `entry_signal_always_on` สร้างสัญญาณเข้าไม้ตลอดปี
+- ปรับ pipeline ใน `run_backtest` และ `run_backtest_multi_tf` ใช้โหมด `trend_follow`

--- a/changelog.md
+++ b/changelog.md
@@ -386,3 +386,9 @@
 ### Changed
 - ปิดไม้เร็วหาก ATR/gain_z ต่ำหลังถือ 25 แท่ง
 - Recovery mode ลดความเสี่ยงเมื่อ momentum ไม่ดี
+
+## [v1.9.58] — 2025-07-28
+### Added
+- ฟังก์ชัน `entry_signal_always_on` สำหรับเข้าไม้ต่อเนื่อง
+### Changed
+- เปลี่ยน pipeline backtest ใช้ `entry_signal_always_on` โหมด `trend_follow`

--- a/tests/test_enterprise.py
+++ b/tests/test_enterprise.py
@@ -462,6 +462,23 @@ class TestSpikeNewsGuard(unittest.TestCase):
         res = enterprise.multi_session_trend_scalping(df)
         self.assertTrue((res["entry_signal"] == "buy").any())
 
+    def test_entry_signal_always_on_every_bar(self):
+        df = pd.DataFrame({"ema_fast": [2, 2, 2], "ema_slow": [1, 1, 1]})
+        res = enterprise.entry_signal_always_on(df, mode="every_bar")
+        self.assertEqual(res["entry_signal"].tolist(), ["buy", "sell", "buy"])
+
+    def test_entry_signal_always_on_step(self):
+        df = pd.DataFrame({"ema_fast": [2] * 5, "ema_slow": [1] * 5})
+        res = enterprise.entry_signal_always_on(df, mode="step", step=2)
+        self.assertEqual(
+            res["entry_signal"].dropna().tolist(), ["buy", "sell", "buy"]
+        )
+
+    def test_entry_signal_always_on_trend_follow(self):
+        df = pd.DataFrame({"ema_fast": [2, 1], "ema_slow": [1, 2]})
+        res = enterprise.entry_signal_always_on(df, mode="trend_follow")
+        self.assertEqual(res["entry_signal"].tolist(), ["buy", "sell"])
+
     def test_constants_values(self):
         self.assertEqual(enterprise.COMMISSION_PER_LOT, 0.10)
         self.assertEqual(enterprise.SLIPPAGE, 0.2)


### PR DESCRIPTION
## Summary
- add `entry_signal_always_on` for continuous trade entries
- use new signal in `run_backtest`, `run_backtest_multi_tf`, and walk-forward pipeline
- document update in agent.md and changelog
- test new function with three modes

## Testing
- `pytest -q`