### PR TITLE
Implement relaxed trend entry and update tests

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -100,3 +100,10 @@
 ## v3.22 QA Patch
 - เพิ่มฟังก์ชัน `entry_signal_always_on` สร้างสัญญาณเข้าไม้ตลอดปี
 - ปรับ pipeline ใน `run_backtest` และ `run_backtest_multi_tf` ใช้โหมด `trend_follow`
+## v3.23 QA Patch
+- เพิ่มฟังก์ชัน `entry_signal_trend_relax` เข้าตามเทรนด์เมื่อ ATR สูงกว่าค่าเฉลี่ย
+- ใช้สัญญาณใหม่นี้ใน `run_backtest`, `run_backtest_multi_tf`, และ `run_walkforward_backtest`
+- ผ่อนคลาย Early Force Close เพียงแจ้งเตือนไม่ปิดสถานะ
+- ปรับ OMS kill switch ให้เป็นแค่คำเตือน
+- ลดการ Boost lot และ Recovery ให้ไม่รุนแรง
+

--- a/changelog.md
+++ b/changelog.md
@@ -392,3 +392,11 @@
 - ฟังก์ชัน `entry_signal_always_on` สำหรับเข้าไม้ต่อเนื่อง
 ### Changed
 - เปลี่ยน pipeline backtest ใช้ `entry_signal_always_on` โหมด `trend_follow`
+## [v1.9.59] — 2025-07-29
+### Added
+- ฟังก์ชัน `entry_signal_trend_relax` เข้าไม้เมื่อ EMA cross และ ATR สูงกว่าค่าเฉลี่ย
+### Changed
+- ใช้ `entry_signal_trend_relax` ใน backtest ทั้งหมด
+- Early force close เปลี่ยนเป็น warning เท่านั้น
+- ลด boost lot และ recovery multiplier
+

--- a/tests/test_enterprise.py
+++ b/tests/test_enterprise.py
@@ -479,6 +479,21 @@ class TestSpikeNewsGuard(unittest.TestCase):
         res = enterprise.entry_signal_always_on(df, mode="trend_follow")
         self.assertEqual(res["entry_signal"].tolist(), ["buy", "sell"])
 
+    def test_entry_signal_trend_relax_basic(self):
+        df = pd.DataFrame(
+            {
+                "timestamp": pd.date_range("2020-01-01", periods=4, freq="min"),
+                "ema_fast": [1, 2, 1, 2],
+                "ema_slow": [2, 1, 2, 1],
+                "high": [1.1, 1.2, 1.1, 1.2],
+                "low": [0.9, 0.8, 0.9, 0.8],
+                "atr": [0.2, 0.3, 0.4, 0.5],
+            }
+        )
+        res = enterprise.entry_signal_trend_relax(df, min_gap_minutes=0)
+        self.assertIn("entry_signal", res.columns)
+        self.assertTrue(res["entry_signal"].notna().any())
+
     def test_constants_values(self):
         self.assertEqual(enterprise.COMMISSION_PER_LOT, 0.10)
         self.assertEqual(enterprise.SLIPPAGE, 0.2)


### PR DESCRIPTION
## Summary
- add `entry_signal_trend_relax` for trend-follow entries when ATR is above average
- use the new signal in all backtests
- relax OMS kill switch and early force close logic
- tone down lot sizing boosts
- test coverage for `entry_signal_trend_relax`

## Testing
- `pytest -q`