### PR TITLE
Add relaxed entry signal with walk-forward logging

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -107,3 +107,7 @@
 - ปรับ OMS kill switch ให้เป็นแค่คำเตือน
 - ลดการ Boost lot และ Recovery ให้ไม่รุนแรง
 
+## v3.24 QA Patch
+- เพิ่ม `calc_basic_indicators`, `relaxed_entry_signal` และ `walkforward_run`
+- ระบบ Force Entry เมื่อไม่มีสัญญาณนานเกินกำหนดและ QA Log ต่อ Fold
+

--- a/changelog.md
+++ b/changelog.md
@@ -400,3 +400,9 @@
 - Early force close เปลี่ยนเป็น warning เท่านั้น
 - ลด boost lot และ recovery multiplier
 
+## [v1.9.60] — 2025-07-30
+### Added
+- ฟังก์ชัน `calc_basic_indicators`, `relaxed_entry_signal` และ `walkforward_run`
+### Changed
+- เพิ่มระบบ Force Entry ในช่วงไม่มีสัญญาณและ QA log ต่อ fold
+

--- a/tests/test_enterprise.py
+++ b/tests/test_enterprise.py
@@ -584,6 +584,43 @@ class TestSpikeNewsGuard(unittest.TestCase):
         self.assertIn("max_win_streak", stats)
         self.assertIn("max_loss_streak", stats)
 
+    def test_calc_basic_indicators_columns(self):
+        df = pd.DataFrame(
+            {
+                "close": [1, 2, 3, 4, 5],
+                "high": [1, 2, 3, 4, 5],
+                "low": [0.5, 1, 1.5, 2, 2.5],
+            }
+        )
+        res = enterprise.calc_basic_indicators(df)
+        for c in ["EMA_20", "EMA_50", "RSI_14", "ATR_14"]:
+            self.assertIn(c, res.columns)
+
+    def test_relaxed_entry_signal_force_gap(self):
+        df = pd.DataFrame(
+            {
+                "open": [1, 1.1] * 10,
+                "close": [1.2, 0.9] * 10,
+                "high": [1.3, 1.2] * 10,
+                "low": [0.8, 0.7] * 10,
+            }
+        )
+        df = enterprise.calc_basic_indicators(df)
+        res = enterprise.relaxed_entry_signal(df, force_gap=1)
+        self.assertTrue(res["entry_signal"].notna().any())
+
+    def test_walkforward_run_returns_list(self):
+        df = pd.DataFrame(
+            {
+                "open": [1] * 10,
+                "close": [1] * 10,
+                "high": [1] * 10,
+                "low": [1] * 10,
+            }
+        )
+        folds = enterprise.walkforward_run(df, fold_size=3)
+        self.assertEqual(len(folds), 4)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- implement `calc_basic_indicators`, `relaxed_entry_signal`, and `walkforward_run` in `enterprise.py`
- provide new example in `__main__` for running walk-forward
- document patch in `agent.md` and `changelog.md`
- test new functions in `tests/test_enterprise.py`

## Testing
- `pytest -q`