### PR TITLE
Implement MAX_RAM_MODE indicators and RAM logging

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -80,3 +80,8 @@
 - เพิ่มฟังก์ชัน `multi_session_trend_scalping` และใช้ใน pipeline `run_backtest`
 - บันทึกจำนวนสัญญาณเข้าออเดอร์แบบละเอียด
 
+## v3.19 QA Patch
+- เพิ่มตัวแปร `MAX_RAM_MODE` และฟังก์ชัน `log_ram_usage`
+- คำนวณ EMA/RSI/ATR หลายช่วงเมื่อเปิดโหมดใช้แรมสูง
+- บันทึกการใช้ RAM ก่อนและหลังรัน backtest
+

--- a/changelog.md
+++ b/changelog.md
@@ -406,3 +406,10 @@
 ### Changed
 - เพิ่มระบบ Force Entry ในช่วงไม่มีสัญญาณและ QA log ต่อ fold
 
+## [v1.9.61] — 2025-07-31
+### Added
+- ตัวแปร `MAX_RAM_MODE` และฟังก์ชัน `log_ram_usage`
+### Changed
+- `calc_indicators`, `label_elliott_wave`, `detect_divergence`, `calc_gain_zscore`, `calc_signal_score` รองรับโหมดใช้แรมสูง
+- บันทึกการใช้ RAM ก่อนและหลัง `_execute_backtest`
+

--- a/tests/test_enterprise.py
+++ b/tests/test_enterprise.py
@@ -28,8 +28,14 @@ class TestEnterprise(unittest.TestCase):
             }
         )
         res = enterprise.calc_indicators(df)
-        for col in ["ema_fast", "ema_slow", "rsi", "atr", "adx"]:
+        for col in ["ema_fast", "ema_slow", "rsi", "atr", "adx", "ema_55", "rsi_14"]:
             self.assertIn(col, res.columns)
+
+    def test_log_ram_usage_logs(self):
+        logger = enterprise.logger
+        with self.assertLogs(logger, level="INFO") as cm:
+            enterprise.log_ram_usage("test")
+        self.assertTrue(any("RAM usage" in msg for msg in cm.output))
 
     def test_rsi_function(self):
         ser = pd.Series([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], dtype=float)


### PR DESCRIPTION
## Summary
- add optional psutil-based RAM logging helper and MAX_RAM_MODE flag
- extend indicator calculation and other helper functions when MAX_RAM_MODE is enabled
- log RAM usage before and after backtest execution
- implement placeholder helper functions for unit tests
- update agent and changelog docs
- expand tests to cover RAM logging

## Testing
- `pytest -q`