### PR TITLE
Implement smart entry enterprise v1

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -85,3 +85,8 @@
 - คำนวณ EMA/RSI/ATR หลายช่วงเมื่อเปิดโหมดใช้แรมสูง
 - บันทึกการใช้ RAM ก่อนและหลังรัน backtest
 
+
+## v3.20 QA Patch
+- เพิ่มฟังก์ชัน `smart_entry_signal_enterprise_v1` ใช้สัญญาณแบบ Multi-confirm
+- ปรับ `_execute_backtest` ตรวจ strict confirm ใน Recovery และ QA monitor loss streak
+- `run_backtest` เรียกใช้สัญญาณใหม่

--- a/changelog.md
+++ b/changelog.md
@@ -413,3 +413,10 @@
 - `calc_indicators`, `label_elliott_wave`, `detect_divergence`, `calc_gain_zscore`, `calc_signal_score` รองรับโหมดใช้แรมสูง
 - บันทึกการใช้ RAM ก่อนและหลัง `_execute_backtest`
 
+
+## [v1.9.62] — 2025-07-31
+### Added
+- ฟังก์ชัน `smart_entry_signal_enterprise_v1` แบบ Multi-confirm และ Force Entry filter
+### Changed
+- `_execute_backtest` เพิ่ม Recovery strict confirm และ QA monitor
+- `run_backtest` ใช้สัญญาณใหม่

--- a/tests/test_enterprise.py
+++ b/tests/test_enterprise.py
@@ -615,6 +615,22 @@ class TestSpikeNewsGuard(unittest.TestCase):
         res = enterprise.relaxed_entry_signal(df, force_gap=1)
         self.assertTrue(res["entry_signal"].notna().any())
 
+    def test_smart_entry_signal_enterprise_v1_force_and_counts(self):
+        df = pd.DataFrame(
+            {
+                "ema_fast": [2, 2, 0, 0],
+                "ema_slow": [1, 1, 1, 1],
+                "rsi": [60, 60, 40, 40],
+                "adx": [20, 20, 20, 20],
+                "gain_z": [0.6, 0.6, -0.6, -0.6],
+                "divergence": ["bullish", "bullish", "bearish", "bearish"],
+                "wave_phase": ["trough", "trough", "peak", "peak"],
+                "timestamp": pd.date_range("2020-01-01", periods=4, freq="min"),
+            }
+        )
+        res = enterprise.smart_entry_signal_enterprise_v1(df, force_entry_gap=1)
+        self.assertEqual(res["entry_signal"].tolist(), ["buy", "buy", "sell", "sell"])
+
     def test_walkforward_run_returns_list(self):
         df = pd.DataFrame(
             {


### PR DESCRIPTION
## Summary
- add `smart_entry_signal_enterprise_v1` for multi-confirm entries
- tighten recovery confirmation and add QA monitoring
- integrate new entry signal into `run_backtest`
- document patch in changelog and agent guide
- test new entry signal

## Testing
- `pytest -q`