### PR TITLE
Implement aggressive entry mode

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -99,3 +99,6 @@
 - `smart_entry_signal_enterprise_v1` เพิ่ม QA Guard ตรวจจำนวนสัญญาณลดลง
 - `_execute_backtest` ปรับ Adaptive Entry เฉพาะจุดเมื่ออยู่ใน Recovery Mode
 - ปรับ Trailing SL หลัง TP1 ให้ทำงานเมื่อ ADX > 20
+
+## v3.23 QA Patch
+- เพิ่มโหมด Aggressive Entry ใช้สัญญาณสลับทุกแท่งและ lot sizing ใหม่

--- a/changelog.md
+++ b/changelog.md
@@ -432,3 +432,9 @@
 ### Changed
 - `_execute_backtest` ใช้ Adaptive Entry แบบ strict เมื่อแพ้ต่อเนื่อง >= 4
 - ปรับ Trailing SL หลัง TP1 ให้ทำงานเมื่อ ADX สูง
+
+## [v1.9.65] — 2025-08-01
+### Added
+- โหมด Aggressive Entry สลับ buy/sell ทุกแท่ง
+### Changed
+- ปรับ risk_per_trade เป็น 4% และลด min_sl_dist เหลือ 2 จุด


### PR DESCRIPTION
## Summary
- adjust trading parameters for aggressive mode
- implement alternate entry signal and lot sizing
- add aggressive backtest workflow
- document aggressive entry mode in agent.md and changelog
- test aggressive functions

## Testing
- `pytest -q`