### PR TITLE
ปรับพารามิเตอร์ความเสี่ยงและยืนยันเทรนด์ M15

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -105,3 +105,9 @@
 
 ## v3.24 QA Patch
 - เพิ่มฟังก์ชัน `entry_signal_trend_scalp` ใช้ Trend Scalping พร้อม Force Entry
+
+## v3.25 QA Patch
+- ปรับ risk_per_trade เป็น 3% และขยาย TP1/TP2 เป็น 3.0/6.0
+- เพิ่มตรวจ signal_score และเทรนด์ M15 ใน generate_signal
+- calculate_position_size ปรับความเสี่ยงตาม ADX และจำกัด lot ตาม equity
+

--- a/changelog.md
+++ b/changelog.md
@@ -442,3 +442,12 @@
 ## [v1.9.66] — 2025-08-02
 ### Added
 - ฟังก์ชัน `entry_signal_trend_scalp` ใช้ Trend Scalping พร้อม Force Entry
+## [v1.9.67] — 2025-08-03
+### Changed
+- ปรับ risk_per_trade เป็น 3% และเพิ่ม lot_max เป็น 10
+- TP1/TP2 multiplier ขยายเป็น 3.0/6.0 และ sl_mult ลดเหลือ 1.0
+- กำหนดเวลาเทรด 0-24h และเข้าสู่โหมด Recovery หลังแพ้ 2 ไม้
+- Force entry gap ลดเหลือ 200 แท่ง
+- ฟังก์ชัน generate_signal ตรวจ minimum signal_score และเช็คแนวโน้ม M15
+- calculate_position_size ปรับสเกลความเสี่ยงตาม ADX และจำกัด lot ตาม equity
+

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -6,7 +6,8 @@ import enterprise as runtime
 class TestRuntime(unittest.TestCase):
     def test_generate_signal_true(self):
         price = {"breakout": True}
-        ind = {"EMA50": 2, "EMA200": 1, "ADX": 30, "ADX_trend": "BUY"}
+        ind = {"EMA50": 2, "EMA200": 1, "ADX": 30, "ADX_trend": "BUY", "signal_score": 2,
+               "m15_ema_fast": 2, "m15_ema_slow": 1}
         now = datetime(2020, 1, 1, 10)
         self.assertTrue(
             runtime.generate_signal(
@@ -19,7 +20,8 @@ class TestRuntime(unittest.TestCase):
         )
 
     def test_calculate_position_size(self):
-        lot = runtime.calculate_position_size(1000, 10, 9.5, 0.01)
+        indicators = {"ADX": 30}
+        lot = runtime.calculate_position_size(1000, 10, 9.5, 0.01, indicators)
         self.assertGreater(lot, 0)
 
     def test_on_order_execute_and_update(self):
@@ -42,6 +44,13 @@ class TestRuntime(unittest.TestCase):
         p.drawdown = 0.01
         runtime.manage_recovery(p)
         self.assertFalse(p.recovery_active)
+
+    def test_calculate_position_size_risk_scaling(self):
+        ind_low = {"ADX": 10}
+        ind_high = {"ADX": 40}
+        lot_low = runtime.calculate_position_size(100, 10, 9, 0.01, ind_low)
+        lot_high = runtime.calculate_position_size(100, 10, 9, 0.01, ind_high)
+        self.assertGreater(lot_high, lot_low)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Notes
- เพิ่มค่าความเสี่ยงต่อไม้เป็น 3% ปรับ TP1/TP2 เป็น 3/6 และลด sl_mult เป็น 1
- เพิ่มการตรวจสอบ signal_score และเทรนด์จากกรอบเวลา M15 ใน `generate_signal`
- `calculate_position_size` ปรับสัดส่วนความเสี่ยงตามค่า ADX และจำกัด lot ตามทุน
- เพิ่มฟังก์ชัน `entry_signal_trend_scalp`, `calc_aggressive_lot`, `run_backtest_aggressive`
- อัปเดตเอกสาร agent.md และ changelog.md พร้อมเพิ่ม unit tests

## Testing
- `pytest -q`