### PR TITLE
ปรับ risk_per_trade และ session bias

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -111,3 +111,12 @@
 - เพิ่มตรวจ signal_score และเทรนด์ M15 ใน generate_signal
 - calculate_position_size ปรับความเสี่ยงตาม ADX และจำกัด lot ตาม equity
 
+## v3.26 QA Patch
+- ลด risk_per_trade เป็น 2%
+- เพิ่ม kill_switch_dd เป็น 50%
+- adx_thresh ปรับเป็น 15
+- force_entry_gap เป็น 300
+- ยกเลิกลิมิต lot สูงสุด 0.05
+- apply_session_bias ไม่กรอง session ใด ๆ
+- `_execute_backtest` ข้ามสัญญาณที่ divergence ตรงข้าม
+

--- a/changelog.md
+++ b/changelog.md
@@ -451,3 +451,13 @@
 - ฟังก์ชัน generate_signal ตรวจ minimum signal_score และเช็คแนวโน้ม M15
 - calculate_position_size ปรับสเกลความเสี่ยงตาม ADX และจำกัด lot ตาม equity
 
+## [v1.9.68] — 2025-08-04
+### Changed
+- ลด risk_per_trade เป็น 2%
+- ปรับ kill_switch_dd เป็น 50%
+- เพิ่ม adx_thresh เป็น 15
+- force_entry_gap เป็น 300
+- ยกเลิกลิมิต lot สูงสุด 0.05 ใน `OMSManager`
+- `apply_session_bias` ไม่บล็อก session ใด
+- `_execute_backtest` ข้ามสัญญาณถ้า divergence สวนทาง
+


### PR DESCRIPTION
## Summary
- ลด risk_per_trade เป็น 2%
- เพิ่มขีดจำกัด drawdown เป็น 50%
- ปรับค่า adx_thresh และ force_entry_gap
- ไม่บล็อก session ใดใน `apply_session_bias`
- ยกเลิกลิมิต lot 0.05 และเพิ่มเงื่อนไข divergence ใน `_execute_backtest`
- อัปเดต agent.md และ changelog
- ปรับ unit tests ให้สอดคล้องกับพารามิเตอร์ใหม่และเพิ่มกรณีทดสอบ

## Testing
- `pytest -q`