### PR TITLE
Add auto lot scaling and equity TP/SL adjuster

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -126,3 +126,8 @@
 - Partial TP 60% และ trail_stop_mult 0.4
 - เพิ่ม micro SL exit และระบบ re-entry สูงสุด 2 ไม้
 
+## v3.28 QA Patch
+- เพิ่มฟังก์ชันคำนวณล็อตอัตโนมัติ `calculate_auto_lot`
+- เพิ่มฟังก์ชัน `equity_based_tp_sl` ปรับ TP/SL ตามทุน
+- ปรับ `_execute_backtest` ใช้ค่าจากฟังก์ชันใหม่เมื่อเปิดใช้งาน
+

--- a/changelog.md
+++ b/changelog.md
@@ -468,3 +468,9 @@
 - Force entry gap 100 แท่ง พร้อม micro SL exit
 - Partial TP 60% และ trail_stop_mult 0.4 พร้อม re-entry สูงสุด 2 ไม้
 
+## [v1.9.70] — 2025-08-06
+### Added
+- ฟังก์ชัน `calculate_auto_lot` สำหรับปรับขนาดล็อตตามทุนและระยะ SL
+- ฟังก์ชัน `equity_based_tp_sl` กำหนด TP/SL อัตโนมัติตาม Equity
+- ปรับ `_execute_backtest` เรียกใช้ฟังก์ชันใหม่และบันทึก log
+

--- a/tests/test_enterprise.py
+++ b/tests/test_enterprise.py
@@ -806,6 +806,20 @@ class TestSpikeNewsGuard(unittest.TestCase):
                 os.remove(f)
         assert "MicroSL" in trades["exit"].values
 
+    def test_calculate_auto_lot_basic(self):
+        lot = enterprise.calculate_auto_lot(1000, 0.02, 10, 5)
+        self.assertEqual(lot, 2.0)
+
+    def test_equity_based_tp_sl_levels(self):
+        tp, sl = enterprise.equity_based_tp_sl(400)
+        self.assertEqual((tp, sl), (1.5, 0.8))
+        tp2, sl2 = enterprise.equity_based_tp_sl(2000)
+        self.assertEqual((tp2, sl2), (3.5, 1.2))
+
+    def test_config_flags_true(self):
+        self.assertTrue(enterprise.enable_auto_lot_scaling)
+        self.assertTrue(enterprise.enable_equity_tp_sl_adjuster)
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- เพิ่มตัวแปรเปิดใช้งาน `enable_auto_lot_scaling` และ `enable_equity_tp_sl_adjuster`
- สร้างฟังก์ชัน `calculate_auto_lot` และ `equity_based_tp_sl`
- ปรับ `_execute_backtest` ให้ใช้ฟังก์ชันใหม่ในการคำนวณ TP/SL และ lot
- อัปเดต `agent.md` และ `changelog.md`
- เพิ่ม unit tests ตรวจสอบฟังก์ชันใหม่

## Testing
- `pytest -q`