### PR TITLE
Implement Patch G for entry signal

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -137,3 +137,7 @@
 
 ## v3.30 QA Patch
 - รวมระบบ Walk Forward Analysis เข้า enterprise.py และเพิ่มเมนู CLI เลือกโหมด
+
+## v3.31 QA Patch
+- [Patch G] ปรับสัญญาณ smart_entry_signal_enterprise_v1 ลด gain_z threshold, รองรับ wave_phase="mid" และ force_entry_gap=50
+

--- a/changelog.md
+++ b/changelog.md
@@ -484,3 +484,8 @@
 ### Added
 - รวมระบบ Walk Forward Analysis เข้า enterprise.py และเพิ่มเมนู CLI เลือกโหมด
 
+
+## [v1.9.73] — 2025-08-09
+### Changed
+- [Patch G] ปรับ smart_entry_signal_enterprise_v1 ลด gain_z threshold และเพิ่มเงื่อนไข wave_phase="mid" พร้อมลด force_entry_gap เป็น 50 และปิด QA Entry Drop Guard
+


### PR DESCRIPTION
## Summary
- relax `smart_entry_signal_enterprise_v1` thresholds and allow wave_phase=`mid`
- reduce `force_entry_gap` to 50 and disable entry count QA guard
- add debug logging
- document Patch G in `agent.md` and `changelog.md`
- adapt unit tests and add coverage for new mid-wave logic

## Testing
- `pytest -q`