### PR TITLE
Patch H: adjust CLI default to WFA

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -141,3 +141,7 @@
 ## v3.31 QA Patch
 - [Patch G] ปรับสัญญาณ smart_entry_signal_enterprise_v1 ลด gain_z threshold, รองรับ wave_phase="mid" และ force_entry_gap=50
 
+## v3.32 QA Patch
+- ปรับเมนู CLI ตัด Basic Backtest และเหลือเฉพาะ Walk Forward กับ Multi-TF
+- โหมดเริ่มต้นเรียก `walk_forward_run` พร้อม debug log
+

--- a/changelog.md
+++ b/changelog.md
@@ -489,3 +489,8 @@
 ### Changed
 - [Patch G] ปรับ smart_entry_signal_enterprise_v1 ลด gain_z threshold และเพิ่มเงื่อนไข wave_phase="mid" พร้อมลด force_entry_gap เป็น 50 และปิด QA Entry Drop Guard
 
+## [v1.9.74] — 2025-08-10
+### Changed
+- ปรับเมนู CLI เหลือสองตัวเลือก (WFA, Multi-TF) และเรียก `walk_forward_run` เป็นค่าเริ่มต้น
+- เพิ่ม debug log ในฟังก์ชัน `main` และบล็อก `__main__`
+

--- a/enterprise.py
+++ b/enterprise.py
@@ -2399,19 +2399,19 @@ def walk_forward_run(path, fold_days=30):
 def main():
     print("\n👉 Select Mode:")
     print("  [1] Walk Forward Analysis (WFA)")
-    print("  [2] Basic Backtest")
-    print("  [3] Multi-TF Backtest")
+    print("  [2] Multi-TF Backtest")
     mode = input("Enter mode number: ").strip()
     file_input = input("CSV file path (default: trade_log.csv): ").strip() or "trade_log.csv"
+    logger.debug("[CLI] Selected mode=%s file=%s", mode, file_input)
     if mode == "1":
         walk_forward_run(file_input)
     elif mode == "2":
-        run_backtest(file_input)
-    elif mode == "3":
         run_backtest_multi_tf()
     else:
         print("❌ Invalid mode")
 
 
 if __name__ == "__main__":
-    main()
+    # [Patch H] Default = Walk-Forward Validation
+    logger.debug("[Patch H] auto-start walk_forward_run")
+    walk_forward_run("trade_log.csv")

--- a/tests/test_enterprise.py
+++ b/tests/test_enterprise.py
@@ -881,6 +881,25 @@ class TestSpikeNewsGuard(unittest.TestCase):
             if f.startswith("shap_summary_fold_"):
                 os.remove(f)
 
+    def test_main_menu_calls_correct_functions(self):
+        with patch("builtins.input", side_effect=["1", "file.csv"]), patch.object(
+            enterprise, "walk_forward_run"
+        ) as mwfa:
+            enterprise.main()
+            mwfa.assert_called_with("file.csv")
+
+        with patch("builtins.input", side_effect=["2", "file.csv"]), patch.object(
+            enterprise, "run_backtest_multi_tf"
+        ) as mmulti:
+            enterprise.main()
+            mmulti.assert_called_with()
+
+    def test_default_main_block_calls_wfa(self):
+        import inspect
+
+        src = inspect.getsource(enterprise)
+        self.assertIn("walk_forward_run(\"trade_log.csv\")", src)
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- update CLI to only offer WFA and multi-TF backtest
- default run now triggers walk_forward_run
- add debug logs for mode selection
- document patch in agent.md and changelog
- test new CLI behaviour

## Testing
- `pytest -q`