### PR TITLE
ปรับปรุงการรัน Walk-Forward Validation แบบ Manual

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -3,4 +3,5 @@
 This document describes the NICEGOLD QA backtest agent.
 
 - **Patch v1.0.2**: Replace Walk Forward Analysis CLI with Walk-Forward Validation.
+- **Patch v1.0.3**: Update deprecated `walk_forward_run` message and run WFV manually in `__main__`.
 

--- a/changelog.md
+++ b/changelog.md
@@ -18,3 +18,8 @@
 ### Changed
 - Replaced WFA CLI with Walk-Forward Validation approach.
 
+## [v1.0.3] — 2025-05-25
+### Changed
+- Updated deprecated `walk_forward_run` message.
+- Main block now runs Walk-Forward Validation on the first fold.
+

--- a/enterprise.py
+++ b/enterprise.py
@@ -2103,9 +2103,13 @@ def main():
 
 def walk_forward_run(trade_data_path, fold_days=30):
     """[Patch] WFA deprecated; retained for compatibility."""
-    logger.info("[Patch] walk_forward_run() is deprecated")
+    logger.info("[Patch] walk_forward_run() is deprecated - replaced by WFV")
     pass
 
 
 if __name__ == "__main__":
-    walk_forward_run("trade_log.csv")
+    logger.info("[Patch] Manual run WFV from M1_PATH (Fold 1 only)")
+    df = load_data(M1_PATH)
+    df = data_quality_check(df)
+    folds = split_folds(df, n_folds=5)
+    run_walkforward_backtest(folds[0:1], n_folds=1)

--- a/tests/test_enterprise.py
+++ b/tests/test_enterprise.py
@@ -897,11 +897,12 @@ class TestSpikeNewsGuard(unittest.TestCase):
             enterprise.main()
             mwfv.assert_called()
 
-    def test_default_main_block_calls_wfa(self):
+    def test_default_main_block_manual_wfv(self):
         import inspect
 
         src = inspect.getsource(enterprise)
-        self.assertIn("walk_forward_run(\"trade_log.csv\")", src)
+        self.assertIn("Manual run WFV from M1_PATH", src)
+        self.assertIn("run_walkforward_backtest(folds[0:1], n_folds=1)", src)
 
 
 


### PR DESCRIPTION
## สิ่งที่ทำ
- ปรับข้อความ logger ใน `walk_forward_run` ให้ระบุว่าถูกแทนที่ด้วย WFV
- เปลี่ยนบล็อก `__main__` ให้รัน WFV จาก `M1_PATH` (Fold แรก)
- อัปเดต `agent.md` และ `changelog.md`
- แก้ไข unit test ให้ตรวจสอบบล็อกใหม่

## ผลการทดสอบ
- `pytest -q` ผ่านทั้งหมด