### PR TITLE
Implement auto-learning WFV with strategy selection

### DIFF
--- a/AGENTS.md.
+++ b/AGENTS.md.
@@ -43,4 +43,4 @@
 
 ---
 อัพเดต AGENTS.md. และ changelog.md. ทุกครั้งหลังอัพเดตแพท ให้ทันปัจจุบัน
-- Sprint A: Rolling WFV with optimization and visual summary
+- Sprint A: Auto-learning WFV with strategy selection and final backtest

--- a/changelog.md
+++ b/changelog.md
@@ -4,3 +4,8 @@
 ### Added
 - Rolling Walk-Forward Validation with per-fold parameter optimization.
 - Visual summary charts and strategy comparison.
+
+## [v1.0.6] — 2025-05-25
+### Added
+- Auto-learning WFV that carries best params per strategy.
+- Automatic strategy selection and final backtest execution.

--- a/tests/test_enterprise.py
+++ b/tests/test_enterprise.py
@@ -898,8 +898,13 @@ class TestSpikeNewsGuard(unittest.TestCase):
             enterprise, "label_elliott_wave", return_value=pd.DataFrame()), patch.object(
             enterprise, "detect_divergence", return_value=pd.DataFrame()), patch.object(
             enterprise, "calc_gain_zscore", return_value=pd.DataFrame()), patch.object(
-            enterprise, "run_wfv_rolling_with_optimization") as mwfv, patch.object(
+            enterprise,
+            "run_wfv_rolling_with_optimization",
+            return_value=([], "goldai2025"),
+        ) as mwfv, patch.object(
             enterprise, "plot_wfv_summary"
+        ), patch.object(
+            enterprise, "run_final_backtest_with_best_strategy"
         ):
             enterprise.main()
             mwfv.assert_called()
@@ -944,9 +949,10 @@ class TestSpikeNewsGuard(unittest.TestCase):
             "parameter_grid_search",
             return_value=(pd.DataFrame({"pnl": [1]}), {}),
         ):
-            res = enterprise.run_wfv_rolling_with_optimization(df, window_size=2, step_size=1)
+            res, best_strat = enterprise.run_wfv_rolling_with_optimization(df, window_size=2, step_size=1)
         self.assertIsInstance(res, list)
         self.assertGreater(len(res), 0)
+        self.assertIsInstance(best_strat, str)
 
     def test_plot_wfv_summary_returns_df(self):
         results = [


### PR DESCRIPTION
## Summary
- extend WFV optimizer to warm-start from previous best config
- auto-select best strategy across folds and run final backtest
- adjust main and CLI to use selected strategy
- update AGENTS and changelog for new patch
- update unit tests for new return value and main flow

## Testing
- `pytest -q`